### PR TITLE
error handling prototype

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -62,6 +62,22 @@ func Test_Integration(t *testing.T) {
 	os.Clearenv()
 }
 
+func Test_Integration_FileNotFound(t *testing.T) {
+	t.Parallel()
+
+	var testConfig struct{}
+	err := From("i_dont_exist.txt").To(&testConfig)
+
+	confErr := err.(*Error)
+
+	if !confErr.FileNotExistErrors() {
+		t.Errorf("expected file not found error")
+	}
+	if confErr.FileParseErrors() {
+		t.Errorf("expected to not have general file erros")
+	}
+}
+
 func Test_stringToSlice(t *testing.T) {
 	t.Parallel()
 	type args struct {
@@ -232,7 +248,8 @@ func Test_convertAndSetValue(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			convertAndSetValue(tt.args.settable, tt.args.s)
+			err := convertAndSetValue(tt.args.settable, tt.args.s)
+			t.Log(err)
 			if !reflect.DeepEqual(tt.args.settable, tt.want) {
 				t.Errorf("convertAndSetValue = %v, want %v", tt.args.settable, tt.want)
 			}
@@ -272,7 +289,8 @@ func Test_convertAndSetSlice(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			convertAndSetSlice(tt.args.slicePtr, tt.args.values)
+			b := &Builder{}
+			b.convertAndSetSlice(tt.args.slicePtr, tt.args.values, "TODO")
 		})
 	}
 }

--- a/error.go
+++ b/error.go
@@ -1,0 +1,95 @@
+package config
+
+import (
+	"fmt"
+	"os"
+)
+
+type Error struct {
+	fileErrors  []error
+	fieldErrors []error
+}
+
+func (e *Error) Error() string {
+	var all []error
+	for _, err := range e.fileErrors {
+		all = append(all, err)
+	}
+	for _, err := range e.fieldErrors {
+		all = append(all, err)
+	}
+	return fmt.Sprintf("%v", all)
+}
+
+func (e *Error) FileNotExistErrors() bool {
+	if e == nil {
+		return false
+	}
+	for _, err := range e.fileErrors {
+		if os.IsNotExist(err) {
+			return true
+		}
+	}
+	return false
+}
+
+func (e *Error) FileParseErrors() bool {
+	if e == nil {
+		return false
+	}
+	for _, err := range e.fileErrors {
+		if !os.IsNotExist(err) {
+			return true
+		}
+	}
+	return false
+}
+
+func (e *Error) FieldParseErrors() bool {
+	if e == nil {
+		return false
+	}
+	return len(e.fieldErrors) > 0
+}
+
+func (b *Builder) appendFileError(err error) {
+	if b.err == nil {
+		b.err = &Error{}
+	}
+	b.err.fileErrors = append(b.err.fileErrors, err)
+}
+
+func (b *Builder) appendFieldError(err error, fieldName string, fieldType string) {
+	if b.err == nil {
+		b.err = &Error{}
+	}
+	b.err.fieldErrors = append(b.err.fieldErrors, err)
+}
+
+func (b *Builder) appendSliceError(err error, fieldName, fieldType string, index int) {
+	if b.err == nil {
+		b.err = &Error{}
+	}
+	b.err.fieldErrors = append(b.err.fieldErrors, &sliceError{fieldName, fieldType, index, err})
+}
+
+type fieldError struct {
+	name string
+	t    string
+	err  error
+}
+
+func (e *fieldError) Error() string {
+	return fmt.Sprintf("failed to parse %v value for field %v: %v", e.t, e.name, e.err)
+}
+
+type sliceError struct {
+	name  string
+	t     string
+	index int
+	err   error
+}
+
+func (e *sliceError) Error() string {
+	return fmt.Sprintf("failed to parse %v value for slice %v at index %v: %v", e.t, e.name, e.index, e.err)
+}

--- a/error_test.go
+++ b/error_test.go
@@ -1,0 +1,73 @@
+package config
+
+import (
+	"errors"
+	"os"
+	"strconv"
+	"testing"
+)
+
+func Test_fieldError_Error(t *testing.T) {
+	type fields struct {
+		name string
+		t    string
+		err  error
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		{
+			name: "expected use",
+			fields: fields{
+				name: "port",
+				t:    "int",
+				err:  func() error { _, err := strconv.Atoi("xyz"); return err }(),
+			},
+			want: "failed to parse int value for field port: strconv.Atoi: parsing \"xyz\": invalid syntax",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := &fieldError{
+				name: tt.fields.name,
+				t:    tt.fields.t,
+				err:  tt.fields.err,
+			}
+			if got := e.Error(); got != tt.want {
+				t.Errorf("fieldError.Error() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestError_FileNotExistErrors(t *testing.T) {
+	t.Parallel()
+
+	err := &Error{
+		fileErrors: []error{os.ErrNotExist},
+	}
+
+	if !err.FileNotExistErrors() {
+		t.Errorf("expected file not found error")
+	}
+	if err.FileParseErrors() {
+		t.Errorf("expected to not have general file erros")
+	}
+}
+
+func TestError_FileErrors(t *testing.T) {
+	t.Parallel()
+
+	err := &Error{
+		fileErrors: []error{errors.New("oops")},
+	}
+
+	if err.FileNotExistErrors() {
+		t.Errorf("expected not to have file not found error")
+	}
+	if !err.FileParseErrors() {
+		t.Errorf("expected to have general file erros")
+	}
+}

--- a/example_test.go
+++ b/example_test.go
@@ -4,6 +4,7 @@ package config_test
 import (
 	"fmt"
 	"io/ioutil"
+	"log"
 	"os"
 	"strings"
 
@@ -86,4 +87,18 @@ func Example_structTags() {
 
 	// Output:
 	// db://
+}
+
+func Example_errorHandling() {
+	var c MyConfig
+	err := config.From("i_dont_exist.txt").FromEnv().To(&c)
+
+	if e, ok := err.(*config.Error); ok {
+		switch {
+		case e.FileNotExistErrors():
+			// continue, allow fields
+		case e.FieldParseErrors() || e.FileParseErrors():
+			log.Fatalf("Failed to parse some fields: %v", e.Error())
+		}
+	}
 }


### PR DESCRIPTION
@freman my stab at error handling. I need to clean a lot up, but I wanted to get your input on it.

A couple of key points: 

* `config` is a very high-level API. As such, many different types of errors can happen. In addition, multiple errors can happen at once, and the consumer may want to still continue. Hence, the aggregation.
* a single error type is returned. This allows easy future API updates while maintaining backwards compatibility, preventing the need for a v2.
* Adding methods to inspect the type of error is stolen from [the net package](https://golang.org/pkg/net/#Error)
* I think we also need a way to inspect the type of field errors.
  * e.g. a field error on `DATABASE_URL` is not allowed, but `FEATURE_FLAG` is allowed.

I'm debating on removing the type switch, and changing the error API to be similar to the [os package](https://golang.org/pkg/os/#IsNotExist)